### PR TITLE
Develop

### DIFF
--- a/rede-woocommerce/rede-woocommerce.php
+++ b/rede-woocommerce/rede-woocommerce.php
@@ -1,9 +1,10 @@
 <?php
 /**
  * Plugin Name: Rede WooCommerce
+ * Plugin URI:        https://github.com/DevelopersRede/woocommerce
  * Description: Rede API integration for WooCommerce
  * Author:      Rede
- * Version:     1.0.0
+ * Version:     1.2.2
  * Text Domain: rede-woocommerce
  *
  * @package WC_Rede
@@ -17,7 +18,7 @@ if (!class_exists('WC_Rede')) :
     class WC_Rede
     {
 
-        const VERSION = '1.0.0';
+        const VERSION = '1.2.2';
 
         protected static $instance = null;
 


### PR DESCRIPTION
Atualizei o número de versão no plugin para coincidir com os números de releases e ficar mais claro aos usuários que o plugin foi atualizado depois do lançamento. Resolve incidente #13 .

"O número de versão do plugin, no código, está como 1.0.0, entretanto, já há release versão 1.2.1, o que pode levar a certas confusões e dar a impressão que o plugin não tem sido atualizado desde sua primeira versão."

